### PR TITLE
remove TELUS digital

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ Jump to section:
 |[SoundHound](https://soundhound.com/)|Voice interfaces|Santa Clara, CA|[SoundHound careers](soundhound.com/careers)|
 |[SpankChain](https://spankchain.com/)|Blockchain, adult industry, social justice|Los Angeles, CA|[SpankChain jobs](https://spankchain.com/jobs)|
 |[Square](https://squareup.com)|Financial services, mobile payments, payments hardware, and e-commerce|San Francisco, CA|[Square careers](https://squareup.com/ca/en/careers)|
-|[TELUS Digital](https://www.telus.com/)|Digital Labs for a major Canadian Telecom|Vancouver, BC|[TELUS Digital careers](https://labs.telus.com/careers)|
 |[Trend Micro](https://www.trendmicro.com/)|Security|Tokyo, Japan|[Trend Micro careers](https://www.trendmicro.com/en_ca/about/careers.html)|
 |[Turbonomic](https://turbonomic.com/)|Workload automation for the cloud|Boston, MA|[Turbonomic careers](https://turbonomic.com/company/careers/)|
 |[Uber](https://www.uber.com/ca/en/)|ride-sharing, food delivery, self-driving cars|San Francisco, CA|[Uber Careers](https://www.uber.com/ca/en/careers/list/?department=Engineering&location=CAN-Ontario-Toronto)


### PR DESCRIPTION
TELUS digital is not a company of it's own, it's just a department within TELUS ... which is a telco business, doesn't quite fit the rest of this list.